### PR TITLE
Fix: single hero query bug, Feat: find items and add main_attribute to scrap return

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "semi": false,
   "printWidth": 120,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "endOfLine": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 ]
 ```
 
-> https://dota2api.vercel.app/api/heroes?heroe=axe
+> https://dota2api.vercel.app/api/heroes?hero=axe
 ```json
 {
     "name": "Axe",

--- a/api/items.ts
+++ b/api/items.ts
@@ -1,0 +1,20 @@
+import { NowRequest, NowResponse } from '@vercel/node'
+import { Dota2 } from '../helpers/dota2'
+
+const dota2 = new Dota2()
+
+export default async function (req: NowRequest, res: NowResponse): Promise<NowResponse> {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+
+  try {
+    if (req.query.item) return res.send(await dota2.findItem(req.query.item as string))
+
+    const items = await dota2.listItems()
+
+    return res.send(items)
+  } catch (err) {
+    return res.status(500).send({
+      error: err.message,
+    })
+  }
+}

--- a/helpers/dota2.ts
+++ b/helpers/dota2.ts
@@ -5,6 +5,7 @@ import { Scrap } from './scrap'
 
 export class Dota2 {
   private DOTA_URL = 'http://www.dota2.com'
+  private DOTA_ITEM_IMG_URL = 'https://cdn.cloudflare.steamstatic.com/apps/dota2/images/items'
   private info: AxiosInstance
   private heroesImages: IDota2HeroImage[]
   public heroesList: IDota2Hero[]
@@ -75,6 +76,10 @@ export class Dota2 {
     return heroImage[hero]
   }
 
+  private itemImageLinkProvider(link: string) {
+    return `${this.DOTA_ITEM_IMG_URL}/${link.slice(0, -2)}`
+  }
+
   public async listItems(): Promise<IDota2Item[]> {
     const { data } = await this.info.get('/jsfeed/itemdata')
 
@@ -82,6 +87,7 @@ export class Dota2 {
     const items = Object.keys(itemsData).map((itemKey) => ({
       slug: itemKey,
       ...itemsData[itemKey],
+      img: this.itemImageLinkProvider(itemsData[itemKey].img),
     }))
 
     this.itemsList = items
@@ -97,6 +103,6 @@ export class Dota2 {
 
     if (!itemData) throw new RequestError('item not found')
 
-    return { slug: item, ...itemData }
+    return { slug: item, ...itemData, img: this.itemImageLinkProvider(itemData.img) }
   }
 }

--- a/helpers/dota2.ts
+++ b/helpers/dota2.ts
@@ -36,7 +36,15 @@ export class Dota2 {
     const heroes = await this.info.get('/jsfeed/heropickerdata')
     const heroesList = await this.fillHeroesWithImages(heroes.data)
 
-    this.heroesList = heroesList
+    this.heroesList = heroesList.sort((a, b) => {
+      if (a.name < b.name) {
+        return -1
+      }
+      if (a.name > b.name) {
+        return 1
+      }
+      return 0
+    })
 
     return this.heroesList
   }

--- a/helpers/dota2.ts
+++ b/helpers/dota2.ts
@@ -1,13 +1,13 @@
 import axios, { AxiosInstance } from 'axios'
 import { RequestError } from './error'
-import { IDota2Heroe, IDota2HeroeImage } from './interfaces/dota2.interface'
+import { IDota2Hero, IDota2HeroImage } from './interfaces/dota2.interface'
 import { Scrap } from './scrap'
 
 export class Dota2 {
   private DOTA_URL = 'http://www.dota2.com'
   private heroesInfo: AxiosInstance
-  private heroesImages: IDota2HeroeImage[]
-  public heroesList: IDota2Heroe[]
+  private heroesImages: IDota2HeroImage[]
+  public heroesList: IDota2Hero[]
 
   constructor() {
     this.heroesInfo = axios.create({
@@ -31,7 +31,7 @@ export class Dota2 {
     return { ...heroInfo, ...heroImage }
   }
 
-  public async listHeroes(): Promise<IDota2Heroe[]> {
+  public async listHeroes(): Promise<IDota2Hero[]> {
     const heroes = await this.heroesInfo.get('/jsfeed/heropickerdata')
     const heroesList = await this.fillHeroesWithImages(heroes.data)
 
@@ -40,7 +40,7 @@ export class Dota2 {
     return this.heroesList
   }
 
-  private async getHeroesImages(): Promise<IDota2HeroeImage[]> {
+  private async getHeroesImages(): Promise<IDota2HeroImage[]> {
     const { data } = await this.heroesInfo.get('/heroes')
 
     const heroesImages = new Scrap(data).scrapHeroes()
@@ -48,7 +48,7 @@ export class Dota2 {
     return heroesImages
   }
 
-  private async fillHeroesWithImages(heroes: IDota2Heroe[]) {
+  private async fillHeroesWithImages(heroes: IDota2Hero[]) {
     const heroesImages = await this.getHeroesImages()
     const filledImageHeroes = Object.keys(heroes).map((hero) => {
       const heroImage = heroesImages.find((hImg) => hImg[hero])

--- a/helpers/dota2.ts
+++ b/helpers/dota2.ts
@@ -24,9 +24,9 @@ export class Dota2 {
     const heroes = data
     const heroInfo = heroes[hero]
 
-    if (!heroInfo) throw new RequestError('heroe not found')
+    if (!heroInfo) throw new RequestError('hero not found')
 
-    const heroImage = await this.findHeroeImage(hero)
+    const heroImage = await this.findHeroImage(hero)
 
     return { ...heroInfo, ...heroImage }
   }
@@ -58,7 +58,7 @@ export class Dota2 {
     return filledImageHeroes
   }
 
-  private async findHeroeImage(hero: string) {
+  private async findHeroImage(hero: string) {
     if (!this.heroesImages) this.heroesImages = await this.getHeroesImages()
 
     const heroImage = this.heroesImages.find((heroImage) => heroImage[hero])

--- a/helpers/interfaces/dota2.interface.ts
+++ b/helpers/interfaces/dota2.interface.ts
@@ -17,3 +17,20 @@ export interface IDota2HeroImageInfo {
 }
 
 export type IDota2HeroImage = Record<string, IDota2HeroImageInfo>
+
+export interface IDota2Item {
+  slug: string
+  id: number
+  img: string
+  dname: string
+  qual: string
+  cost: number
+  desc: string
+  notes: string
+  attrib: string
+  mc: string
+  cd: number
+  lore: string
+  components: null
+  created: boolean
+}

--- a/helpers/interfaces/dota2.interface.ts
+++ b/helpers/interfaces/dota2.interface.ts
@@ -1,4 +1,4 @@
-export interface IDota2Heroe {
+export interface IDota2Hero {
   avatar?: string
   slug?: string
   info_url?: string
@@ -10,9 +10,10 @@ export interface IDota2Heroe {
   roles_l: string[]
 }
 
-export interface IDota2HeroeImageInfo {
+export interface IDota2HeroImageInfo {
   avatar: string
   info_url: string
+  main_attribute: string
 }
 
-export type IDota2HeroeImage = Record<string, IDota2HeroeImageInfo>
+export type IDota2HeroImage = Record<string, IDota2HeroImageInfo>

--- a/helpers/scrap.ts
+++ b/helpers/scrap.ts
@@ -1,5 +1,5 @@
 import cheerio from 'cheerio'
-import { IDota2HeroeImage } from './interfaces/dota2.interface'
+import { IDota2HeroImage } from './interfaces/dota2.interface'
 
 export class Scrap {
   private html: string
@@ -9,7 +9,7 @@ export class Scrap {
     this.html = html
   }
 
-  public scrapHeroes(): IDota2HeroeImage[] {
+  public scrapHeroes(): IDota2HeroImage[] {
     const $ = cheerio.load(this.html)
     const heroes = []
 
@@ -29,7 +29,7 @@ export class Scrap {
             slug: heroId,
             avatar: $(this).find('img').first().attr('src'),
             info_url: $(this).attr('href'),
-            mainAttribute: heroMainAttribute,
+            main_attribute: heroMainAttribute,
           },
         })
       })

--- a/helpers/scrap.ts
+++ b/helpers/scrap.ts
@@ -13,15 +13,23 @@ export class Scrap {
     const $ = cheerio.load(this.html)
     const heroes = []
 
+    const mainAttributeClasses = {
+      heroColLeft: 'strength',
+      heroColMiddle: 'agility',
+      heroColRight: 'intelligence',
+    }
+
     $('.heroIcons')
       .find('a')
       .each(function () {
-        const heroeId = $(this).attr('id').replace(/link_/g, '')
+        const heroId = $(this).attr('id').replace(/link_/g, '')
+        const heroMainAttribute = mainAttributeClasses[$(this).parent().parent().attr('class')]
         heroes.push({
-          [heroeId]: {
-            slug: heroeId,
+          [heroId]: {
+            slug: heroId,
             avatar: $(this).find('img').first().attr('src'),
             info_url: $(this).attr('href'),
+            mainAttribute: heroMainAttribute,
           },
         })
       })


### PR DESCRIPTION
## Fix

Fix single hero query bug, replacing (when singular) "Heroe" to "Hero" in all interfaces and classes

## Feat

Find items and add main_attribute (intelligence, strength, agility) to ScrapHero return